### PR TITLE
Beschränkung der POIs

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -32,7 +32,7 @@ class DashboardController < ApplicationController
     if helpers.visible_in_role?("role_point_of_interest")
       poi_results = @smart_village.query <<~GRAPHQL
         query {
-          pointsOfInterest {
+          pointsOfInterest(category: "Fahrradvermietung/-service") {
             id
           }
         }

--- a/app/controllers/point_of_interests_controller.rb
+++ b/app/controllers/point_of_interests_controller.rb
@@ -8,7 +8,7 @@ class PointOfInterestsController < ApplicationController
   def index
     results = @smart_village.query <<~GRAPHQL
       query {
-        pointsOfInterest {
+        pointsOfInterest(category: "Fahrradvermietung/-service") {
           id
           name
           visible


### PR DESCRIPTION
Es werden unter anderem auch wegen der Performance nicht mehr alle POIs geladen,
sondern nur noch diejenigen aus der Kategorie "15" .

Alle anderen POIs sind derzeit nicht für BBNavi relevant.

BBNAV-97